### PR TITLE
Install wp-cli during travis-ci testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-sudo: false
+sudo: true
 
 php:
     - 5.5
@@ -25,8 +25,9 @@ matrix:
     fast_finish: true
 
 before_install:
-    - composer create-project wp-cli/wp-cli /usr/share/wp-cli --no-dev
-    - sudo ln -s /usr/share/wp-cli/bin/wp /usr/bin/wp
+    - curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+    - chmod +x wp-cli.phar
+    - sudo mv wp-cli.phar /usr/local/bin/wp
 
 before_script:
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION


### PR DESCRIPTION
This should allow us to include dependency plugins later.
